### PR TITLE
fix: reading reactInternals from null instance

### DIFF
--- a/src/ReactEighteenAdapter.ts
+++ b/src/ReactEighteenAdapter.ts
@@ -474,12 +474,13 @@ class ReactEighteenAdapter extends EnzymeAdapter {
 					if (!instance) {
 						node = null;
 					}
-	
-					node = getNodeFromRootFinder(
-						adapter.isCustomComponent,
-						toTree(instance._reactInternals),
-						options,
-					);
+					else {
+						node = getNodeFromRootFinder(
+							adapter.isCustomComponent,
+							toTree(instance._reactInternals),
+							options,
+						);
+					}
 				});
 				if (unmountFlag) {
 					wrapAct(() => {


### PR DESCRIPTION
The `onRenderCb` sets the `instance` after `getNode()` gets called, which inside the `wrapAct` tries to access the `_reactInternals` property of `instance` (by that time `null`), thus raising `TypeError: Cannot read properties of null (reading '_reactInternals')`.