### PR TITLE
Fix peer dependency issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,6 @@ typings/
 # TernJS port file
 .tern-port
 
-dist
+dist/
+
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,13 @@
         "enzyme-shallow-equal": "^1.0.0"
       },
       "devDependencies": {
-        "@types/enzyme": "^3.10.13",
+        "@types/enzyme": "^3.10.14",
+        "@types/has": "^1.0.0",
         "@types/node": "^17.0.23",
+        "@types/react": "^18.0.21",
+        "@types/react-dom": "^18.0.0",
+        "@types/react-is": "^18.2.2",
+        "@types/react-test-renderer": "^18.0.0",
         "enzyme": "^3.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -39,9 +44,9 @@
       }
     },
     "node_modules/@types/enzyme": {
-      "version": "3.10.13",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.13.tgz",
-      "integrity": "sha512-FCtoUhmFsud0Yx9fmZk179GkdZ4U9B0GFte64/Md+W/agx0L5SxsIIbhLBOxIb9y2UfBA4WQnaG1Od/UsUQs9Q==",
+      "version": "3.10.14",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.14.tgz",
+      "integrity": "sha512-JeTG2MNUX1bH2DqccwUe3SuPoLu+kUz5UgR3Tvl9nBdfNj7rBZscytctSjEatd5Ul9GXXGKaQBaxODIgJYVRqA==",
       "dev": true,
       "dependencies": {
         "@types/cheerio": "*",
@@ -59,6 +64,12 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/has": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/has/-/has-1.0.0.tgz",
+      "integrity": "sha512-1J4U6Ipq5B+ytzNa9XWYg+U5cI5nt12a+RiISbKD9a74QDoRVhoBd6GPtd+imkqQRaTGO1l6bvdP1cqsM6dCpw==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -70,6 +81,44 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.24.tgz",
+      "integrity": "sha512-Ee0Jt4sbJxMu1iDcetZEIKQr99J1Zfb6D4F3qfUWoR1JpInkY1Wdg4WwCyBjL257D0+jGqSl1twBjV8iCaC0Aw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
+      "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-is": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.2.tgz",
+      "integrity": "sha512-bNmRDADVsOivYLvqYQATYRbf60SlK++spu97SK65pSCjdtuTqczFexBQtOK+gQdG6cqOsvQZ3mR12ueEoaq5iA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.3.tgz",
+      "integrity": "sha512-4wcNLnY6nIT+L6g94CpzL4CXX2P18JvKPU9CDlaHr3DnbP3GiaQLhDotJqjWlVqOcE4UhLRjp0MtxqwuNKONnA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
@@ -1122,9 +1171,9 @@
       }
     },
     "@types/enzyme": {
-      "version": "3.10.13",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.13.tgz",
-      "integrity": "sha512-FCtoUhmFsud0Yx9fmZk179GkdZ4U9B0GFte64/Md+W/agx0L5SxsIIbhLBOxIb9y2UfBA4WQnaG1Od/UsUQs9Q==",
+      "version": "3.10.14",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.14.tgz",
+      "integrity": "sha512-JeTG2MNUX1bH2DqccwUe3SuPoLu+kUz5UgR3Tvl9nBdfNj7rBZscytctSjEatd5Ul9GXXGKaQBaxODIgJYVRqA==",
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
@@ -1144,6 +1193,12 @@
         }
       }
     },
+    "@types/has": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/has/-/has-1.0.0.tgz",
+      "integrity": "sha512-1J4U6Ipq5B+ytzNa9XWYg+U5cI5nt12a+RiISbKD9a74QDoRVhoBd6GPtd+imkqQRaTGO1l6bvdP1cqsM6dCpw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -1155,6 +1210,44 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "dev": true
+    },
+    "@types/react": {
+      "version": "18.2.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.24.tgz",
+      "integrity": "sha512-Ee0Jt4sbJxMu1iDcetZEIKQr99J1Zfb6D4F3qfUWoR1JpInkY1Wdg4WwCyBjL257D0+jGqSl1twBjV8iCaC0Aw==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
+      "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-is": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.2.tgz",
+      "integrity": "sha512-bNmRDADVsOivYLvqYQATYRbf60SlK++spu97SK65pSCjdtuTqczFexBQtOK+gQdG6cqOsvQZ3mR12ueEoaq5iA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.3.tgz",
+      "integrity": "sha512-4wcNLnY6nIT+L6g94CpzL4CXX2P18JvKPU9CDlaHr3DnbP3GiaQLhDotJqjWlVqOcE4UhLRjp0MtxqwuNKONnA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/scheduler": {
       "version": "0.16.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "enzyme-shallow-equal": "^1.0.0",
-        "react-is": "^18.2.0",
-        "react-test-renderer": "^18.2.0"
+        "enzyme-shallow-equal": "^1.0.0"
       },
       "devDependencies": {
         "@types/enzyme": "^3.10.13",
@@ -19,12 +17,16 @@
         "enzyme": "^3.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-is": "^18.2.0",
+        "react-test-renderer": "^18.2.0",
         "typescript": "^4.6.3"
       },
       "peerDependencies": {
         "enzyme": "^3.11.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": ">=18",
+        "react-dom": ">=18",
+        "react-is": ">=18",
+        "react-test-renderer": ">=18"
       }
     },
     "node_modules/@types/cheerio": {
@@ -46,6 +48,17 @@
         "@types/react": "^16"
       }
     },
+    "node_modules/@types/enzyme/node_modules/@types/react": {
+      "version": "16.14.48",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.48.tgz",
+      "integrity": "sha512-7HP7K9IyuP6CpxEHmfRPEl21pwra+nSgZHXhyq7WOkxhIGYtSpIHJBijh4zuScgelrPxsUXVPDRkSKHhT+6nkg==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -57,17 +70,6 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "dev": true
-    },
-    "node_modules/@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
@@ -703,7 +705,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
@@ -727,6 +730,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -778,6 +782,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -916,6 +921,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -939,12 +945,14 @@
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/react-shallow-renderer": {
       "version": "16.15.0",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
       "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
@@ -957,6 +965,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
       "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
       "dependencies": {
         "react-is": "^18.2.0",
         "react-shallow-renderer": "^16.15.0",
@@ -989,6 +998,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -1119,6 +1129,19 @@
       "requires": {
         "@types/cheerio": "*",
         "@types/react": "^16"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "16.14.48",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.48.tgz",
+          "integrity": "sha512-7HP7K9IyuP6CpxEHmfRPEl21pwra+nSgZHXhyq7WOkxhIGYtSpIHJBijh4zuScgelrPxsUXVPDRkSKHhT+6nkg==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        }
       }
     },
     "@types/node": {
@@ -1132,17 +1155,6 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "dev": true
-    },
-    "@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
-      "dev": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "@types/scheduler": {
       "version": "0.16.3",
@@ -1597,7 +1609,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "lodash.escape": {
       "version": "4.0.1",
@@ -1621,6 +1634,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -1655,7 +1669,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.0",
@@ -1761,6 +1776,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -1778,12 +1794,14 @@
     "react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "react-shallow-renderer": {
       "version": "16.15.0",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
       "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
@@ -1793,6 +1811,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
       "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
       "requires": {
         "react-is": "^18.2.0",
         "react-shallow-renderer": "^16.15.0",
@@ -1819,6 +1838,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,13 @@
     "enzyme-shallow-equal": "^1.0.0"
   },
   "devDependencies": {
-    "@types/enzyme": "^3.10.13",
+    "@types/enzyme": "^3.10.14",
+    "@types/has": "^1.0.0",
     "@types/node": "^17.0.23",
+    "@types/react": "^18.0.21",
+    "@types/react-dom": "^18.0.0",
+    "@types/react-is": "^18.2.2",
+    "@types/react-test-renderer": "^18.0.0",
     "enzyme": "^3.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -28,21 +28,23 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "enzyme-shallow-equal": "^1.0.0",
-    "react-is": "^18.2.0",
-    "react-test-renderer": "^18.2.0"
+    "enzyme-shallow-equal": "^1.0.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.13",
     "@types/node": "^17.0.23",
     "enzyme": "^3.11.0",
-    "typescript": "^4.6.3",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-is": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
+    "typescript": "^4.6.3"
   },
   "peerDependencies": {
     "enzyme": "^3.11.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": ">=18",
+    "react-dom": ">=18",
+    "react-is": ">=18",
+    "react-test-renderer": ">=18"
   }
 }


### PR DESCRIPTION
Using this module results in several warnings regarding peer dependencies:

```
warning " > @cfaester/enzyme-adapter-react-18@0.7.1" has incorrect peer dependency "react@^18.2.0".
warning " > @cfaester/enzyme-adapter-react-18@0.7.1" has incorrect peer dependency "react-dom@^18.2.0".
warning "@cfaester/enzyme-adapter-react-18 > react-test-renderer@18.2.0" has incorrect peer dependency "react@^18.2.0".
```

This is due to an unnecessarily strict peer dependency range `^18.2.0` - The PR replaces that with simply `>=18`.
Also directly related to it, the two dependencies `react-is` and `react-test-renderer` have been moved to **peer dependencies** as well. It is not really recommended to list a specific version of these packages as a _direct_ dependency (unless that specific version is required). Instead, it is better to leave it up to the integrating project to supply a compatible version of the necessary module.
In a separate commit, a few `@types` packages were added to _dev_ dependencies (this could also be moved to a separate PR if preferred, please let me know).