### PR TITLE
Fixed crash when calling .simulate on an emotion styled component

### DIFF
--- a/src/ReactEighteenAdapter.ts
+++ b/src/ReactEighteenAdapter.ts
@@ -300,6 +300,9 @@ function nodeToHostNode(_node) {
 	let node = _node;
 	while (node && !Array.isArray(node) && node.instance === null) {
 		node = node.rendered;
+		if (Array.isArray(node)) {
+			node = node.find(childNode => childNode.rendered !== null);
+		}
 	}
 	// if the SFC returned null effectively, there is no host node.
 	if (!node) {


### PR DESCRIPTION
This fixes #12 for me locally.
Without this fix, I had this error 6 times in a pretty big private codebase.
This fix doesn't result in any problems in this codebase, while it does have ~1500 enzyme unit test cases and ~250 styled components. It also makes heavy use of Material UI V5, which also uses emotion.
I made a minimum reproducible example here: https://github.com/leroydev/enzyme-adapter-react-emotion-issue and also included a way to test this fix by [inlining ReactEighteenAdapter.ts](https://github.com/leroydev/enzyme-adapter-react-emotion-issue/blob/main/changedAdapter/ReactEighteenAdapter.ts) with the proposed change.

After cloning this repo and running `npm i`, the old and new behavior can be compared by running `npm run original-test`/`npm run changed-test` 🙂